### PR TITLE
Remove cookie-based token handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "axios": "^1.10.0",
     "bcryptjs": "^2.4.3",
     "cloudinary": "^2.7.0",
-    "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
@@ -32,7 +31,6 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
-    "@types/cookie-parser": "^1.4.9",
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.3",
     "@types/jsonwebtoken": "^9.0.10",

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,7 +4,6 @@ import helmet from "helmet";
 import morgan from "morgan";
 import dotenv from "dotenv";
 dotenv.config();
-import cookieParser from "cookie-parser";
 import logger from "./utils/logger";
 import { dev, port } from "./utils/helpers";
 import { OK, INTERNAL_SERVER_ERROR } from "./utils/http-status";
@@ -54,8 +53,6 @@ app.use(
 app.use(express.json());
 // Parses URL-encoded data
 app.use(express.urlencoded({ extended: true }));
-// Parses cookies attached to client requests
-app.use(cookieParser());
 
 // Routes
 app.use("/api/auth", authRoutes);

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -1,27 +1,10 @@
-import { Request, Response, NextFunction, CookieOptions } from "express";
+import { Request, Response, NextFunction } from "express";
 import * as AuthService from "../services/auth.service";
 import { AppError } from "../utils/error";
 import { AuthRequest } from "../middleware/auth.middleware";
 import { CREATED, OK } from "../utils/http-status";
 import { dev } from "../utils/helpers";
 
-// Define consistent cookie options for tokens
-const baseCookieOpts: CookieOptions = {
-  httpOnly: true,
-  secure: true,
-  sameSite: "none",
-  path: "/",
-};
-
-const longLivedCookieOpts = {
-  ...baseCookieOpts,
-  maxAge: 7 * 24 * 60 * 60 * 1000, // 7 days
-};
-
-const shortLivedCookieOpts = {
-  ...baseCookieOpts,
-  maxAge: 15 * 60 * 1000, // 15 minutes
-};
 
 // SIGN UP
 const signUp = async (req: Request, res: Response, next: NextFunction) => {
@@ -38,9 +21,6 @@ const signUp = async (req: Request, res: Response, next: NextFunction) => {
       city,
     });
 
-    // Set cookies
-    res.cookie("accessToken", accessToken, longLivedCookieOpts);
-    res.cookie("refreshToken", refreshToken, longLivedCookieOpts);
 
     res.status(CREATED).json({
       status: "success",
@@ -77,9 +57,6 @@ const signIn = async (req: Request, res: Response, next: NextFunction) => {
       password
     );
 
-    // Set cookies
-    res.cookie("accessToken", accessToken, longLivedCookieOpts);
-    res.cookie("refreshToken", refreshToken, longLivedCookieOpts);
 
     res.status(OK).json({
       status: "success",
@@ -108,10 +85,6 @@ const signIn = async (req: Request, res: Response, next: NextFunction) => {
 
 // SIGN OUT
 const signOut = async (req: Request, res: Response) => {
-  // Clear cookies by setting expiration in the past
-  res.cookie("accessToken", "", { expires: new Date(0), ...longLivedCookieOpts });
-  res.cookie("refreshToken", "", { expires: new Date(0), ...longLivedCookieOpts });
-
   res.status(OK).json({
     status: "success",
     message: "Signed out successfully",
@@ -125,14 +98,11 @@ const refreshToken = async (
   next: NextFunction
 ) => {
   try {
-    const token = req.cookies.refreshToken || req.body.refreshToken;
+    const token = req.body.refreshToken;
     if (!token) throw new AppError("Refresh token not provided", 401);
 
     const tokens = await AuthService.refreshToken(token);
 
-    // Set new cookies
-    res.cookie("accessToken", tokens.accessToken, longLivedCookieOpts);
-    res.cookie("refreshToken", tokens.refreshToken, longLivedCookieOpts);
 
     res.status(OK).json({
       status: "success",
@@ -151,10 +121,6 @@ const deleteAccount = async (
 ) => {
   try {
     await AuthService.deleteAccount(req.user.id);
-
-    // Clear cookies
-    res.cookie("accessToken", "", { expires: new Date(0), ...longLivedCookieOpts });
-    res.cookie("refreshToken", "", { expires: new Date(0), ...longLivedCookieOpts });
 
     res.status(OK).json({
       status: "success",

--- a/src/middleware/auth.middleware.ts
+++ b/src/middleware/auth.middleware.ts
@@ -11,18 +11,18 @@ export interface AuthRequest extends Request {
 }
 
 // checks if the user has a valid access token
-export const authorized = async (req: AuthRequest, res: Response, next: NextFunction) => {
+export const authorized = async (
+  req: AuthRequest,
+  res: Response,
+  next: NextFunction
+) => {
   try {
-
-    // 1) Get token from header
+    // 1) Get token from Authorization header
     const authHeader = req.headers.authorization;
     let token: string | undefined;
 
-    // Tries to retrieve the token from either the Authorization header (standard "Bearer <token>") or cookies (accessToken cookie)
     if (authHeader && authHeader.startsWith("Bearer ")) {
       token = authHeader.split(" ")[1];
-    } else if (req.cookies?.accessToken) {
-      token = req.cookies.accessToken;
     }
 
     // Throws a 401 error if no token is found

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -73,7 +73,7 @@ const signIn = async (
   return { user, accessToken, refreshToken };
 };
 
-// Accepts a refreshToken, from cookies or request body
+// Accepts a refreshToken provided in the request body
 const refreshToken = async (
   token: string
 ): Promise<{


### PR DESCRIPTION
## Summary
- stop parsing cookies in the Express app
- return auth tokens directly in JSON responses
- read access tokens solely from the Authorization header
- update refresh token comment
- drop unused cookie-parser dependency

## Testing
- `npm run build` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6886928ced8c83238e6af4f7e8be4281